### PR TITLE
Implement IPC handlers for profile, skills, and preferences (T008-T010)

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -339,6 +339,13 @@ export function registerIpcHandlers() {
 
         return { id: skill.id, ...skill };
       } else {
+        // Check 500-item limit before inserting
+        const countStmt = db.prepare('SELECT COUNT(*) as count FROM skills');
+        const { count } = countStmt.get() as { count: number };
+        if (count >= 500) {
+          throw new Error('Cannot add more than 500 skills');
+        }
+
         // Insert new skill
         const stmt = db.prepare(`
           INSERT INTO skills (name, level, category_id, years_experience)

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -304,7 +304,14 @@ export function registerIpcHandlers() {
         ORDER BY sc.sort_order, s.name
       `);
 
-      return stmt.all();
+      const skills = stmt.all();
+      return skills.map((skill: any) => ({
+        id: skill.id,
+        name: skill.name,
+        category: skill.category_name || '',
+        level: skill.level,
+        yearsOfExperience: skill.years_experience,
+      }));
     } catch (error) {
       log.error('Error getting skills:', error);
       throw error;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -18,6 +18,15 @@ contextBridge.exposeInMainWorld('api', {
   updateProfile: (data: any) => ipcRenderer.invoke(IPC_CHANNELS.PROFILE_UPDATE, data),
   getProfile: () => ipcRenderer.invoke(IPC_CHANNELS.PROFILE_GET),
 
+  // Skills operations
+  getAllSkills: () => ipcRenderer.invoke(IPC_CHANNELS.SKILLS_GET_ALL),
+  upsertSkill: (skill: any) => ipcRenderer.invoke(IPC_CHANNELS.SKILLS_UPSERT, skill),
+  deleteSkill: (id: number) => ipcRenderer.invoke(IPC_CHANNELS.SKILLS_DELETE, id),
+
+  // Preferences operations
+  getPreferences: () => ipcRenderer.invoke(IPC_CHANNELS.PREFERENCES_GET),
+  updatePreferences: (data: any) => ipcRenderer.invoke(IPC_CHANNELS.PREFERENCES_UPDATE, data),
+
   // Matching operations
   runMatch: (jobId: number, profileId: number) => ipcRenderer.invoke(IPC_CHANNELS.MATCH_RUN, jobId, profileId),
   getMatchResults: (jobId: number) => ipcRenderer.invoke(IPC_CHANNELS.MATCH_GET_RESULTS, jobId),
@@ -49,6 +58,11 @@ declare global {
       createProfile: (data: any) => Promise<any>;
       updateProfile: (data: any) => Promise<any>;
       getProfile: () => Promise<any>;
+      getAllSkills: () => Promise<any[]>;
+      upsertSkill: (skill: any) => Promise<any>;
+      deleteSkill: (id: number) => Promise<void>;
+      getPreferences: () => Promise<any>;
+      updatePreferences: (data: any) => Promise<any>;
       runMatch: (jobId: number, profileId: number) => Promise<any>;
       getMatchResults: (jobId: number) => Promise<any>;
       parseLatexCV: (content: string) => Promise<any>;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Global type definitions for Electron API exposed via preload
+ */
+
+interface Window {
+  api: {
+    createJob: (data: any) => Promise<any>;
+    updateJob: (id: number, data: any) => Promise<any>;
+    deleteJob: (id: number) => Promise<void>;
+    getAllJobs: () => Promise<any[]>;
+    getJobById: (id: number) => Promise<any>;
+    createProfile: (data: any) => Promise<any>;
+    updateProfile: (data: any) => Promise<any>;
+    getProfile: () => Promise<any>;
+    getAllSkills: () => Promise<any[]>;
+    upsertSkill: (skill: any) => Promise<any>;
+    deleteSkill: (id: number) => Promise<void>;
+    getPreferences: () => Promise<any>;
+    updatePreferences: (data: any) => Promise<any>;
+    runMatch: (jobId: number, profileId: number) => Promise<any>;
+    getMatchResults: (jobId: number) => Promise<any>;
+    parseLatexCV: (content: string) => Promise<any>;
+    parseJobText: (text: string) => Promise<any>;
+    parsePDF: (filePath: string) => Promise<any>;
+    getSettings: (key: string) => Promise<any>;
+    updateSettings: (key: string, value: any) => Promise<void>;
+    backupDatabase: () => Promise<string>;
+    restoreDatabase: (backupPath: string) => Promise<void>;
+    migrateDatabase: () => Promise<void>;
+  };
+}

--- a/src/renderer/pages/Profile.tsx
+++ b/src/renderer/pages/Profile.tsx
@@ -130,6 +130,44 @@ function Profile() {
 
   const completion = calculateCompletion();
 
+  // Transform DB snake_case to camelCase
+  const transformProfile = (dbProfile: any): UserProfile => ({
+    id: dbProfile.id,
+    firstName: dbProfile.first_name || '',
+    lastName: dbProfile.last_name || '',
+    email: dbProfile.email || '',
+    phone: dbProfile.phone || '',
+    location: dbProfile.location || '',
+    createdAt: dbProfile.created_at ? new Date(dbProfile.created_at) : new Date(),
+    updatedAt: dbProfile.updated_at ? new Date(dbProfile.updated_at) : new Date()
+  });
+
+  const transformSkills = (dbSkills: any[]): HardSkill[] =>
+    dbSkills.map(skill => ({
+      id: skill.id,
+      name: skill.name,
+      level: skill.level,
+      categoryId: skill.category_id,
+      categoryName: skill.category_name,
+      yearsOfExperience: skill.years_experience
+    }));
+
+  const transformPreferences = (dbPrefs: any): UserPreferences => ({
+    minSalary: dbPrefs.min_salary,
+    maxSalary: dbPrefs.max_salary,
+    preferredLocations: dbPrefs.preferred_locations
+      ? JSON.parse(dbPrefs.preferred_locations)
+      : [],
+    willingToRelocate: Boolean(dbPrefs.willing_to_relocate),
+    remoteWorkPreference: dbPrefs.remote_work_preference,
+    preferredRemotePercentage: dbPrefs.preferred_remote_percentage,
+    acceptableRemoteMin: dbPrefs.acceptable_remote_min,
+    acceptableRemoteMax: dbPrefs.acceptable_remote_max,
+    remoteWorkUpdatedAt: dbPrefs.remote_work_updated_at
+      ? new Date(dbPrefs.remote_work_updated_at)
+      : undefined
+  });
+
   // Load profile data
   useEffect(() => {
     const loadProfile = async () => {
@@ -140,10 +178,11 @@ function Profile() {
         const profileData = await window.api.getProfile();
 
         if (profileData) {
-          const { skills: profileSkills, preferences: profilePrefs, ...userProfile } = profileData;
-          setProfile(userProfile as UserProfile);
-          setSkills(profileSkills || []);
-          setPreferences(profilePrefs || null);
+          const { skills: profileSkills, preferences: profilePrefs, ...dbProfile } = profileData;
+
+          setProfile(transformProfile(dbProfile));
+          setSkills(profileSkills ? transformSkills(profileSkills) : []);
+          setPreferences(profilePrefs ? transformPreferences(profilePrefs) : null);
         } else {
           setProfile(null);
           setSkills([]);
@@ -161,8 +200,9 @@ function Profile() {
 
   const handleProfileSave = async (profileData: Partial<UserProfile>) => {
     try {
-      const savedProfile = await window.api.updateProfile(profileData);
-      setProfile(prev => prev ? { ...prev, ...savedProfile } : savedProfile);
+      await window.api.updateProfile(profileData);
+      // Update local state optimistically
+      setProfile(prev => prev ? { ...prev, ...profileData } : null);
     } catch (error) {
       console.error('Failed to save profile:', error);
       throw error;
@@ -182,8 +222,9 @@ function Profile() {
 
   const handlePreferencesSave = async (preferencesData: UserPreferences) => {
     try {
-      const savedPrefs = await window.api.updatePreferences(preferencesData);
-      setPreferences(savedPrefs);
+      await window.api.updatePreferences(preferencesData);
+      // Update local state optimistically
+      setPreferences(preferencesData);
     } catch (error) {
       console.error('Failed to save preferences:', error);
       throw error;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -50,6 +50,15 @@ export const IPC_CHANNELS = {
   PROFILE_UPDATE: 'profile:update',
   PROFILE_GET: 'profile:get',
 
+  // Skills operations
+  SKILLS_GET_ALL: 'skills:getAll',
+  SKILLS_UPSERT: 'skills:upsert',
+  SKILLS_DELETE: 'skills:delete',
+
+  // Preferences operations
+  PREFERENCES_GET: 'preferences:get',
+  PREFERENCES_UPDATE: 'preferences:update',
+
   // Matching operations
   MATCH_RUN: 'match:run',
   MATCH_GET_RESULTS: 'match:getResults',


### PR DESCRIPTION
T008: Profile IPC handlers (already existed)
- PROFILE_GET: Fetch profile with skills and preferences
- PROFILE_UPDATE: Update profile data
- PROFILE_CREATE: Create/upsert profile

T009: Skills IPC handlers
- SKILLS_GET_ALL: Get all skills with categories
- SKILLS_UPSERT: Create or update skill (with 500 limit check)
- SKILLS_DELETE: Remove skill

T010: Preferences IPC handlers
- PREFERENCES_GET: Fetch user preferences
- PREFERENCES_UPDATE: Update preferences with remote work settings

Additional changes:
- Add SKILLS_* and PREFERENCES_* channels to constants.ts
- Update preload.ts with new IPC methods
- Replace mock data in Profile.tsx with real IPC calls
- Add global.d.ts for window.api TypeScript types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage skills in your profile: view, add/update, and delete skills.
  * Edit and save job preferences (salary, locations, remote/relocate options, timing).
  * New app API endpoints enable persistent skills and preferences across sessions.

* **Refactor**
  * Profile page now loads and saves profile, skills, and preferences via the app API.
  * Improved loading indicators and more consistent save flows and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->