### PR TITLE
Fix navigation rendering: Load from Vite dev server and disable useBl…

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -33,10 +33,13 @@ function createWindow() {
   // In development, load from vite dev server. In production, load from built files.
   // electron-vite automatically sets ELECTRON_RENDERER_URL in dev mode
   if (!app.isPackaged && process.env['ELECTRON_RENDERER_URL']) {
+    log.info('Loading from dev server:', process.env['ELECTRON_RENDERER_URL']);
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']);
     mainWindow.webContents.openDevTools();
   } else {
-    mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+    const indexPath = path.join(__dirname, '../renderer/index.html');
+    log.info('Loading from built files:', indexPath);
+    mainWindow.loadFile(indexPath);
   }
 
   // Show window when ready

--- a/src/renderer/components/Layout.tsx
+++ b/src/renderer/components/Layout.tsx
@@ -10,7 +10,6 @@ import {
   Button
 } from '@mui/material';
 import { Sidebar } from './Sidebar';
-import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
 
 export interface UnsavedChangesContextValue {
   isDirty: boolean;
@@ -33,10 +32,18 @@ export const Layout: React.FC = () => {
   const [isDirty, setIsDirty] = React.useState(false);
   const [onSave, setOnSave] = React.useState<(() => Promise<void>) | undefined>(() => undefined);
 
-  // TODO: Re-enable useUnsavedChanges after migrating to createBrowserRouter (Data Router)
+  // TODO(#9): Re-enable useUnsavedChanges after migrating to createBrowserRouter (Data Router)
+  // See: https://github.com/ddumdi11/JobMatchChecker/issues/9
   // const { blocker, handleSave, handleDiscard, handleCancel } = useUnsavedChanges(isDirty, onSave);
 
-  // Temporary: Disable unsaved changes blocker to fix router compatibility
+  // TEMPORARY: Disable unsaved changes blocker to fix router compatibility
+  // WARNING: Users can navigate away without being prompted to save!
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      '⚠️ Unsaved changes protection is disabled. ' +
+      'See https://github.com/ddumdi11/JobMatchChecker/issues/9'
+    );
+  }
   const blocker = { state: 'unblocked' as const };
   const handleSave = async () => {};
   const handleDiscard = () => {};


### PR DESCRIPTION
…ocker

**Problem:**
- Navigation/Sidebar not visible (blank white window)
- Electron loaded from file:// instead of http://localhost:5173
- useBlocker hook caused React Router errors (requires Data Router)

**Solution:**
1. Fix dev server loading in main.ts:
   - Use ELECTRON_RENDERER_URL (set by electron-vite)
   - Check !app.isPackaged for dev mode detection
   - Properly load from Vite dev server in development

2. Temporarily disable useUnsavedChanges hook in Layout.tsx:
   - useBlocker requires createBrowserRouter (Data Router)
   - Current BrowserRouter doesn't support useBlocker
   - TODO: Migrate to createBrowserRouter in future

**Result:**
- ✅ Navigation/Sidebar now visible
- ✅ Hot reload works
- ✅ App fully functional with Electron 38.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Temporarily disabled the unsaved-changes confirmation: navigation proceeds without prompts and no blocking dialogs are shown.
- Chores
  - Improved development startup: when running unpackaged, the app can load the renderer from a configurable dev server URL and logs the source; production continues to load built files and devtools behavior remains tied to the dev load path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->