### PR TITLE
Migrate to createBrowserRouter to enable unsaved changes protection

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
@@ -24,20 +24,37 @@ const theme = createTheme({
   },
 });
 
+// Create router with Data Router API (required for useBlocker)
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />,
+    children: [
+      {
+        index: true,
+        element: <Dashboard />,
+      },
+      {
+        path: 'profile',
+        element: <Profile />,
+      },
+      {
+        path: 'jobs',
+        element: <JobDetail />,
+      },
+      {
+        path: 'settings',
+        element: <Settings />,
+      },
+    ],
+  },
+]);
+
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Router>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<Dashboard />} />
-            <Route path="profile" element={<Profile />} />
-            <Route path="jobs" element={<JobDetail />} />
-            <Route path="settings" element={<Settings />} />
-          </Route>
-        </Routes>
-      </Router>
+      <RouterProvider router={router} />
     </ThemeProvider>
   );
 }

--- a/src/renderer/components/Layout.tsx
+++ b/src/renderer/components/Layout.tsx
@@ -10,6 +10,7 @@ import {
   Button
 } from '@mui/material';
 import { Sidebar } from './Sidebar';
+import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
 
 export interface UnsavedChangesContextValue {
   isDirty: boolean;
@@ -32,22 +33,8 @@ export const Layout: React.FC = () => {
   const [isDirty, setIsDirty] = React.useState(false);
   const [onSave, setOnSave] = React.useState<(() => Promise<void>) | undefined>(() => undefined);
 
-  // TODO(#9): Re-enable useUnsavedChanges after migrating to createBrowserRouter (Data Router)
-  // See: https://github.com/ddumdi11/JobMatchChecker/issues/9
-  // const { blocker, handleSave, handleDiscard, handleCancel } = useUnsavedChanges(isDirty, onSave);
-
-  // TEMPORARY: Disable unsaved changes blocker to fix router compatibility
-  // WARNING: Users can navigate away without being prompted to save!
-  if (process.env.NODE_ENV === 'development') {
-    console.warn(
-      '⚠️ Unsaved changes protection is disabled. ' +
-      'See https://github.com/ddumdi11/JobMatchChecker/issues/9'
-    );
-  }
-  const blocker = { state: 'unblocked' as const };
-  const handleSave = async () => {};
-  const handleDiscard = () => {};
-  const handleCancel = () => {};
+  // Re-enabled after migrating to createBrowserRouter (fixes #9)
+  const { blocker, handleSave, handleDiscard, handleCancel } = useUnsavedChanges(isDirty, onSave);
 
   const contextValue: UnsavedChangesContextValue = {
     isDirty,


### PR DESCRIPTION
## Summary
Migrates from `<BrowserRouter>` to `createBrowserRouter` (Data Router API) to enable `useBlocker` functionality for unsaved changes protection.

## Changes
- ✅ Replace `BrowserRouter` with `createBrowserRouter` in [App.tsx](src/renderer/App.tsx)
- ✅ Convert route configuration to Data Router format
- ✅ Re-enable `useUnsavedChanges` hook in [Layout.tsx](src/renderer/components/Layout.tsx)
- ✅ Remove temporary stub and console warning

## Testing
- ✅ App builds successfully (`npm run build:renderer`)
- ✅ Navigation works (Dashboard, Profile, Settings, Jobs)
- ⚠️ Unsaved changes dialog not yet triggered (requires component integration)

## Related Issues
- Fixes #9 (partial - router migration)
- Follow-up needed: Component integration to actually use `useUnsavedChangesContext`

## Notes
This PR provides the **foundation** for unsaved changes protection by enabling the Data Router API. Individual components (ProfileForm, SkillsManager, PreferencesPanel, future Jobs/Settings forms) still need to integrate with `useUnsavedChangesContext` to trigger the dialog.

A separate issue will be created for the component integration work.

## Acceptance Criteria Met
- [x] App uses `createBrowserRouter` (Data Router)
- [x] `useUnsavedChanges` hook is re-enabled
- [x] All existing routes still work
- [x] Navigation works as expected
- [ ] Unsaved changes dialog shows (deferred to follow-up issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Restored the unsaved changes prompt when navigating away from pages with pending edits.
  - Ensures users are warned before losing in-progress form data.

- Refactor
  - Updated the app’s routing to a new data-driven router, enabling smoother navigation and more reliable route handling.
  - Centralized route configuration for clearer navigation flows and improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->