### PR TITLE
feat: Allow removing preferred locations via Chip delete

### DIFF
--- a/src/renderer/components/PreferencesPanel.tsx
+++ b/src/renderer/components/PreferencesPanel.tsx
@@ -11,7 +11,8 @@ import {
   FormControl,
   InputLabel,
   Select,
-  MenuItem
+  MenuItem,
+  Chip
 } from '@mui/material';
 import { Save as SaveIcon } from '@mui/icons-material';
 import {
@@ -264,9 +265,16 @@ export const PreferencesPanel: React.FC = () => {
           {formData.preferredLocations.length > 0 && (
             <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
               {formData.preferredLocations.map((loc, idx) => (
-                <Typography key={idx} variant="body2" sx={{ bgcolor: 'primary.light', color: 'white', px: 1.5, py: 0.5, borderRadius: 2 }}>
-                  {loc}
-                </Typography>
+                <Chip
+                  key={idx}
+                  label={loc}
+                  onDelete={() => setFormData(prev => ({
+                    ...prev,
+                    preferredLocations: prev.preferredLocations.filter((_, i) => i !== idx)
+                  }))}
+                  color="primary"
+                  disabled={isLoading}
+                />
               ))}
             </Box>
           )}


### PR DESCRIPTION
## Summary

- Replace `Typography` with MUI `Chip` component for preferred location tags
- Add `onDelete` handler to remove locations from the list
- Chip is disabled during loading state

## Test

Manual test confirmed:
- ✅ Add location works
- ✅ Remove location via X-button works  
- ✅ Dirty dialog triggers on unsaved changes
- ✅ Save persists updated location list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive controls to preferred locations in the Preferences panel. Users can now easily remove locations from their preferences list.

* **Improvements**
  * Enhanced location display with improved UI components that provide better interactivity and visual feedback during loading states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->