### PR TITLE
feat: Disable Match button when job already has match result

### DIFF
--- a/src/renderer/pages/JobDetail.tsx
+++ b/src/renderer/pages/JobDetail.tsx
@@ -680,14 +680,16 @@ export default function JobDetail() {
 
                     {hasExistingMatch && (
                       <Tooltip title="Erneut matchen (kostet API-Tokens)">
-                        <Button
-                          variant="outlined"
-                          onClick={handleReMatch}
-                          disabled={isMatching}
-                          startIcon={isMatching ? <CircularProgress size={20} /> : <RefreshIcon />}
-                        >
-                          Erneut matchen
-                        </Button>
+                        <span>
+                          <Button
+                            variant="outlined"
+                            onClick={handleReMatch}
+                            disabled={isMatching}
+                            startIcon={isMatching ? <CircularProgress size={20} /> : <RefreshIcon />}
+                          >
+                            Erneut matchen
+                          </Button>
+                        </span>
                       </Tooltip>
                     )}
                   </>


### PR DESCRIPTION
Closes #40

## Summary
- "Matchen" Button ist `disabled` wenn `currentJob.matchScore !== null`
- Tooltip auf disabled Button: "Bereits gematcht – nutze Erneut matchen"
- "Erneut matchen" Button erscheint nur wenn bereits ein Match existiert
- "Erneut matchen" wird während des Matchings ebenfalls disabled (verhindert Doppelklicks)

## Test plan
- [ ] Job mit Match-Score öffnen → "Matchen" Button ist ausgegraut mit Tooltip
- [ ] Job ohne Match-Score öffnen → "Matchen" Button ist aktiv
- [ ] "Erneut matchen" Button bleibt bei gematchten Jobs aktiv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Re-match" action for jobs that already have a previous match.

* **Improvements**
  * Primary match button now reflects existing matches (disabled when applicable) and shows contextual tooltips.
  * Loading indicators and accessibility-friendly button content preserved for clearer feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->