### PR TITLE
feat: Bulk export to ZIP (Markdown + JSON)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "electron-better-ipc": "^2.0.1",
         "electron-log": "^5.0.0",
         "electron-store": "^8.1.0",
+        "jszip": "^3.10.1",
         "keytar": "^7.9.0",
         "knex": "^3.1.0",
         "papaparse": "^5.4.1",
@@ -5088,7 +5089,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -8275,6 +8275,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9062,6 +9068,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keytar": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
@@ -9258,6 +9312,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -10489,6 +10552,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -10911,9 +10980,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -11857,6 +11924,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "electron-better-ipc": "^2.0.1",
     "electron-log": "^5.0.0",
     "electron-store": "^8.1.0",
+    "jszip": "^3.10.1",
     "keytar": "^7.9.0",
     "knex": "^3.1.0",
     "papaparse": "^5.4.1",

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -898,5 +898,15 @@ export function registerIpcHandlers() {
     }
   });
 
+  // Bulk export multiple jobs to ZIP (Markdown + JSON)
+  ipcMain.handle('export:bulkToZip', async (_, jobIds: number[]) => {
+    try {
+      return await exportService.exportBulkToZip(jobIds);
+    } catch (error: any) {
+      log.error('Error in bulk ZIP export:', error);
+      throw error;
+    }
+  });
+
   log.info('IPC handlers registered successfully');
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -84,5 +84,6 @@ contextBridge.exposeInMainWorld('api', {
   // Export operations
   exportToMarkdown: (jobId: number) => ipcRenderer.invoke('export:toMarkdown', jobId),
   exportToPdf: (jobId: number) => ipcRenderer.invoke('export:toPdf', jobId),
-  exportBulkToPdf: (jobIds: number[]) => ipcRenderer.invoke('export:bulkToPdf', jobIds)
+  exportBulkToPdf: (jobIds: number[]) => ipcRenderer.invoke('export:bulkToPdf', jobIds),
+  exportBulkToZip: (jobIds: number[]) => ipcRenderer.invoke('export:bulkToZip', jobIds)
 });


### PR DESCRIPTION
Closes #34 (Block 2: ZIP Export)

## Summary

Implementiert Bulk-Export als ZIP-Datei mit Markdown + JSON pro Job.

**Funktionsumfang:**
- Neuer "ZIP" Button in Job-Übersicht (neben PDF-Button)
- Nur aktiv wenn ≥1 Job selektiert
- Ergebnis: ZIP-Datei mit 2 Dateien pro Job:
  - `job_<id>_<company>_<title>.md` (via generateMarkdown)
  - `job_<id>_<company>_<title>.json` (pretty-printed JobExportData)

**Technische Details:**
- Library: `jszip` (in-memory ZIP-Erzeugung)
- Filename truncation: Company max 40, Title max 60 Zeichen (Windows path limits)
- Existierende `getJobExportData()` und `generateMarkdown()` wiederverwendet
- Fehlerbehandlung: Fehlgeschlagene Jobs werden übersprungen, Summary zeigt skipped count
- Max 100 Jobs Limit (analog Bulk-PDF)

**IPC/Preload:**
- IPC Handler: `export:bulkToZip`
- Preload API: `exportBulkToZip(jobIds: number[])`

**UI:**
- PDF Button: "PDF (X)" 
- ZIP Button: "ZIP (X)" mit FolderZipIcon
- Success message inkl. skipped count falls vorhanden
- Selection wird nach erfolgreichem Export zurückgesetzt

## Test plan
- [x] 1 Job selektieren → ZIP mit 2 Dateien (.md + .json)
- [x] 10 Jobs selektieren → ZIP mit 20 Dateien
- [x] Build erfolgreich (`npm run build`)
- [ ] Sonderzeichen in Titel/Firma → gültige Dateinamen
- [ ] Lange Titel (>60 Zeichen) → korrekt gekürzt
- [ ] 100+ Jobs → Fehlermeldung "Max 100 Jobs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk ZIP export functionality to download multiple jobs as a single compressed file with job data and markdown representations
  * Updated the interface to display separate PDF and ZIP export buttons when multiple jobs are selected

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->