### PR TITLE
fix: Configurable AI timeouts per use-case + timeout retry

### DIFF
--- a/src/main/services/aiExtractionService.ts
+++ b/src/main/services/aiExtractionService.ts
@@ -7,6 +7,7 @@
 import { sendPrompt } from './aiProviderService';
 import type { AIExtractionResult } from '../../shared/types';
 import { cleanJobUrl } from '../../shared/urlUtils';
+import { TIMEOUT_EXTRACTION_MS } from '../../shared/constants';
 
 /**
  * Extract job fields from unstructured text using the configured AI provider
@@ -66,7 +67,7 @@ Return ONLY valid JSON, no explanation or markdown. If a field cannot be extract
 
     const response = await sendPrompt(
       [{ role: 'user', content: prompt }],
-      { maxTokens: 1024 }
+      { maxTokens: 1024, timeoutMs: TIMEOUT_EXTRACTION_MS }
     );
 
     // Try to extract JSON from markdown code blocks if present

--- a/src/main/services/aiExtractionService.ts
+++ b/src/main/services/aiExtractionService.ts
@@ -4,7 +4,7 @@
  * Uses aiProviderService.sendPrompt() to support Anthropic and OpenRouter.
  */
 
-import { sendPrompt } from './aiProviderService';
+import { sendPrompt, AiTimeoutError } from './aiProviderService';
 import type { AIExtractionResult } from '../../shared/types';
 import { cleanJobUrl } from '../../shared/urlUtils';
 import { TIMEOUT_EXTRACTION_MS } from '../../shared/constants';
@@ -174,8 +174,8 @@ Return ONLY valid JSON, no explanation or markdown. If a field cannot be extract
     };
 
   } catch (error: any) {
-    // Handle timeout
-    if (error.message?.includes('Timeout') || error.message?.includes('abgebrochen')) {
+    // Handle timeout (typed error from the provider layer)
+    if (error instanceof AiTimeoutError) {
       return {
         success: false,
         fields: {

--- a/src/main/services/aiProviderService.ts
+++ b/src/main/services/aiProviderService.ts
@@ -14,6 +14,18 @@ import type { AIProvider, AIProviderConfig, AIMessage, AIResponse, OpenRouterMod
 
 const store = new Store();
 
+/**
+ * Thrown when an AI request is aborted by its timeout.
+ * Distinct type so the retry logic can target ONLY timeouts (not 429 / other errors).
+ */
+export class AiTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number, public readonly provider: AIProvider) {
+    const label = provider === 'anthropic' ? 'Anthropic' : 'OpenRouter';
+    super(`${label}-Anfrage nach ${Math.round(timeoutMs / 1000)} Sekunden abgebrochen (Timeout).`);
+    this.name = 'AiTimeoutError';
+  }
+}
+
 // In-memory cache for OpenRouter models
 let cachedModels: OpenRouterModel[] | null = null;
 let modelsCacheTimestamp = 0;
@@ -89,16 +101,42 @@ export function getApiKey(provider: 'anthropic' | 'openrouter'): string | null {
  */
 export async function sendPrompt(
   messages: AIMessage[],
-  options?: { maxTokens?: number; temperature?: number }
+  options?: { maxTokens?: number; temperature?: number; timeoutMs?: number; retries?: number }
 ): Promise<AIResponse> {
   const config = getProviderConfig();
   const maxTokens = options?.maxTokens ?? 2000;
   const temperature = options?.temperature;
+  const retries = options?.retries ?? 1;
 
-  if (config.provider === 'anthropic') {
-    return sendToAnthropic(messages, config.model, maxTokens, temperature);
-  } else {
-    return sendToOpenRouter(messages, config.model, maxTokens, temperature);
+  // Per-call timeout, falling back to the provider default if not specified
+  const defaultTimeout = config.provider === 'anthropic'
+    ? AI_PROVIDER_DEFAULTS.anthropicTimeout
+    : AI_PROVIDER_DEFAULTS.openRouterTimeout;
+  const timeoutMs = options?.timeoutMs ?? defaultTimeout;
+
+  let attempt = 0;
+  while (true) {
+    try {
+      const result = config.provider === 'anthropic'
+        ? await sendToAnthropic(messages, config.model, maxTokens, timeoutMs, temperature)
+        : await sendToOpenRouter(messages, config.model, maxTokens, timeoutMs, temperature);
+
+      if (attempt > 0) {
+        log.info(`AI-Anfrage nach Retry erfolgreich (Versuch ${attempt + 1}/${retries + 1}, provider: ${config.provider}).`);
+      }
+      return result;
+    } catch (error: any) {
+      // Retry ONLY on timeout/abort — never on 429 or other API errors
+      if (error instanceof AiTimeoutError && attempt < retries) {
+        attempt++;
+        log.warn(
+          `AI-Anfrage nach ${Math.round(timeoutMs / 1000)}s abgebrochen (Timeout). ` +
+          `Starte Retry ${attempt}/${retries} (provider: ${config.provider}).`
+        );
+        continue;
+      }
+      throw error;
+    }
   }
 }
 
@@ -109,6 +147,7 @@ async function sendToAnthropic(
   messages: AIMessage[],
   model: string,
   maxTokens: number,
+  timeoutMs: number,
   temperature?: number
 ): Promise<AIResponse> {
   const apiKey = store.get('anthropic_api_key') as string;
@@ -131,7 +170,7 @@ async function sendToAnthropic(
   }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), AI_PROVIDER_DEFAULTS.anthropicTimeout);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const params: any = {
@@ -170,7 +209,7 @@ async function sendToAnthropic(
     clearTimeout(timeoutId);
 
     if (error.name === 'AbortError' || error.message?.includes('aborted')) {
-      throw new Error('Anthropic-Anfrage nach 30 Sekunden abgebrochen (Timeout).');
+      throw new AiTimeoutError(timeoutMs, 'anthropic');
     }
     if (error.status === 429) {
       throw new Error('Rate-Limit erreicht. Bitte warte einen Moment und versuche es erneut.');
@@ -186,6 +225,7 @@ async function sendToOpenRouter(
   messages: AIMessage[],
   model: string,
   maxTokens: number,
+  timeoutMs: number,
   temperature?: number
 ): Promise<AIResponse> {
   const apiKey = store.get('openrouter_api_key') as string;
@@ -194,7 +234,7 @@ async function sendToOpenRouter(
   }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), AI_PROVIDER_DEFAULTS.openRouterTimeout);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const body: any = {
@@ -256,7 +296,7 @@ async function sendToOpenRouter(
     clearTimeout(timeoutId);
 
     if (error.name === 'AbortError') {
-      throw new Error('OpenRouter-Anfrage nach 60 Sekunden abgebrochen (Timeout). Kostenlose Modelle können langsamer sein.');
+      throw new AiTimeoutError(timeoutMs, 'openrouter');
     }
     throw error;
   }

--- a/src/main/services/matchingService.ts
+++ b/src/main/services/matchingService.ts
@@ -1,6 +1,7 @@
 import { getDatabase } from '../database/db';
 import * as log from 'electron-log';
 import { sendPrompt } from './aiProviderService';
+import { TIMEOUT_MATCHING_MS } from '../../shared/constants';
 
 /**
  * Matching result structure returned by AI analysis
@@ -71,7 +72,7 @@ export async function matchJob(jobId: number): Promise<MatchingResult> {
     log.info('Calling AI for job matching...');
     const aiResponse = await sendPrompt(
       [{ role: 'user', content: prompt }],
-      { maxTokens: 2000 }
+      { maxTokens: 2000, timeoutMs: TIMEOUT_MATCHING_MS }
     );
 
     // 5. Parse Response

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -99,6 +99,14 @@ export const AI_PROVIDER_DEFAULTS = {
   modelCacheTtl: 3_600_000, // 1 hour
 } as const;
 
+/**
+ * Per-use-case timeouts for AI requests (ms).
+ * Matching produces large JSON answers (up to 2000 tokens) from a big prompt
+ * and needs more headroom than the smaller extraction call.
+ */
+export const TIMEOUT_MATCHING_MS = 120_000;
+export const TIMEOUT_EXTRACTION_MS = 30_000;
+
 export const DEFAULT_MATCHING_PROMPT = `You are an expert career advisor and job matching assistant.
 
 Analyze the following job offer and user profile to determine compatibility.

--- a/tests/unit/aiProviderService.test.ts
+++ b/tests/unit/aiProviderService.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for aiProviderService.sendPrompt() retry logic.
+ *
+ * Focus: the timeout-retry behaviour introduced for the matching use-case.
+ * Provider (Anthropic SDK), electron-store and the database are mocked, so these
+ * tests need NO real API key, NO network and NO SQLite — pure logic verification.
+ *
+ * Covered cases:
+ *   a) Timeout → Retry → Success   (and a log.info line is written)
+ *   b) Timeout → Retry → Timeout   (AiTimeoutError is thrown after retries exhausted)
+ *   c) 429 rate-limit              (immediate failure, NO retry)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Hoisted mock handles so the vi.mock factories below can reference them.
+const { createMock, logMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  logMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock the Anthropic SDK — every `new Anthropic()` shares the same create() spy.
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = { create: createMock };
+    constructor(_opts: any) {}
+  },
+}));
+
+// Mock electron-store so an API key is always "configured".
+vi.mock('electron-store', () => ({
+  default: class {
+    get(key: string) {
+      if (key === 'anthropic_api_key') return 'test-anthropic-key';
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+// Mock the database so getProviderConfig() resolves provider=anthropic without SQLite.
+vi.mock('../../src/main/database/db', () => ({
+  getDatabase: () => ({
+    prepare: () => ({
+      get: (key: string) => {
+        if (key === 'ai_provider') return { value: 'anthropic' };
+        if (key === 'ai_model') return { value: 'claude-test-model' };
+        return undefined;
+      },
+    }),
+  }),
+}));
+
+// Mock electron-log so we can assert on log.info / log.warn.
+vi.mock('electron-log', () => logMock);
+
+// Import AFTER the mocks are registered.
+import { sendPrompt, AiTimeoutError } from '../../src/main/services/aiProviderService';
+
+const successResponse = {
+  content: [{ type: 'text', text: 'OK' }],
+  model: 'claude-test-model',
+  usage: { input_tokens: 10, output_tokens: 5 },
+};
+
+/** An error that sendToAnthropic recognises as a timeout/abort. */
+function abortError() {
+  return Object.assign(new Error('Request was aborted'), { name: 'AbortError' });
+}
+
+describe('Unit: aiProviderService.sendPrompt() retry logic', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    logMock.info.mockClear();
+    logMock.warn.mockClear();
+    logMock.error.mockClear();
+  });
+
+  it('a) retries once after a timeout and returns the successful result', async () => {
+    createMock
+      .mockRejectedValueOnce(abortError())   // first attempt → timeout
+      .mockResolvedValueOnce(successResponse); // retry → success
+
+    const result = await sendPrompt([{ role: 'user', content: 'hi' }]);
+
+    expect(result.content).toBe('OK');
+    expect(result.provider).toBe('anthropic');
+    expect(createMock).toHaveBeenCalledTimes(2); // initial + 1 retry
+    // A log line documents the recovered retry so clustered timeouts stay visible.
+    expect(logMock.warn).toHaveBeenCalledWith(expect.stringContaining('Retry'));
+    expect(logMock.info).toHaveBeenCalledWith(expect.stringContaining('Retry erfolgreich'));
+  });
+
+  it('b) throws AiTimeoutError after the retry also times out', async () => {
+    createMock.mockRejectedValue(abortError()); // both attempts time out
+
+    await expect(sendPrompt([{ role: 'user', content: 'hi' }]))
+      .rejects.toBeInstanceOf(AiTimeoutError);
+
+    expect(createMock).toHaveBeenCalledTimes(2); // initial + 1 retry, then give up
+    expect(logMock.info).not.toHaveBeenCalledWith(expect.stringContaining('Retry erfolgreich'));
+  });
+
+  it('c) does NOT retry on a 429 rate-limit error', async () => {
+    createMock.mockRejectedValue(Object.assign(new Error('rate limited'), { status: 429 }));
+
+    await expect(sendPrompt([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/Rate-Limit/);
+
+    expect(createMock).toHaveBeenCalledTimes(1); // no retry for non-timeout errors
+  });
+});


### PR DESCRIPTION
## Problem

Bulk-Matching schlug für **3 von 4 Jobs** fehl mit `Anthropic-Anfrage nach 30 Sekunden abgebrochen (Timeout)`, 1 Job war erfolgreich.

**Root Cause:** Ein einziger globaler 30s-Timeout galt für *jeden* `sendPrompt()`-Aufruf. Der Matching-Use-Case baut einen großen Prompt (Profil + alle Skills + voller Stellentext + Bewertungsrubrik) und fordert bis zu 2000 Output-Tokens inkl. Reasoning an — das überschreitet regelmäßig 30s, während die kleinere Extraktion (1024 Tokens) durchläuft. Das Bulk-Matching war bereits sequenziell (kein Parallelitätsproblem).

## Änderungen

- **`constants.ts`**: Getrennte Konstanten `TIMEOUT_MATCHING_MS` (120s) und `TIMEOUT_EXTRACTION_MS` (30s).
- **`aiProviderService.ts`**: `sendPrompt()` akzeptiert jetzt `timeoutMs` und `retries` (Default `1`). Neue `AiTimeoutError`-Klasse trägt den Timeout-Wert → Fehlermeldung wird **dynamisch** generiert (kein hartkodiertes „30 Sekunden" mehr). Retry erfolgt **nur** bei `AiTimeoutError` — nie bei 429 oder anderen API-Fehlern. `log.warn` vor jedem Retry + `log.info` bei erfolgreichem Retry, damit gehäufte Timeouts im Log sichtbar bleiben.
- **`matchingService.ts`**: Matching nutzt `TIMEOUT_MATCHING_MS` (120s).
- **`aiExtractionService.ts`**: Extraktion bleibt explizit bei `TIMEOUT_EXTRACTION_MS` (30s).
- **`tests/unit/aiProviderService.test.ts`**: Unit-Test für die Retry-Logik mit gemocktem Provider (keine DB, kein Netzwerk):
  - a) Timeout → Retry → Erfolg (inkl. `log.info`-Prüfung)
  - b) Timeout → Retry → Timeout → `AiTimeoutError`
  - c) 429 → sofortiger Fehler, **kein** Retry

## Verifikation

- ✅ **Praxistest:** Bulk-Matching jetzt **4/4 Jobs erfolgreich** (vorher 1/4).
- ✅ Neue Unit-Tests laufen grün (`vitest run tests/unit/aiProviderService.test.ts` → 3 passed).
- ✅ Dynamische Timeout-Meldung wird bis in die Bulk-Ergebnisanzeige durchgereicht (matchJob → bulkMatchJobs → IPC-Handler → JobList), kein alter String klebt mehr.

## Scope-Hinweis

Bewusst **nicht** Teil dieses Branches (separate Maintenance): `better-sqlite3`-Rebuild (`NODE_MODULE_VERSION`-Mismatch lässt vorbestehende DB-Tests fehlschlagen) und Umstellung von `npm test` auf `vitest run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented configurable timeout handling for AI requests with automatic retry logic for timeout failures.
  * AI extraction and matching operations now enforce specific timeout durations for improved reliability.

* **Tests**
  * Added unit tests for timeout handling and retry behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->